### PR TITLE
catch error of json handling

### DIFF
--- a/xfdemo.py
+++ b/xfdemo.py
@@ -200,6 +200,9 @@ class xfdemo(object):
         except TimeoutError as e:
             stg_log(f"reqStatus timeout error occured")
             stg_log(f"{str(e)}")
+        except TypeError as e2:
+            stg_log(f"reqStatus type error occured")
+            stg_log(f"{str(e2)}")
         finally:
             pass
         return 1


### PR DESCRIPTION
The json module will raise an error when handling some of the results returned by API, which is not handled yet, resulting in broken of the program.